### PR TITLE
Add registrar info and handle hidden org data

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -8,6 +8,7 @@ const cleanFromPersonalData = (text) => text.replace(/\d{12}/g, '[REDACTED]');
 const prepareDomainMessage = ({
   domain,
   orgName,
+  registrar,
   clientName,
   clientEmail,
   clientAddress,
@@ -15,10 +16,11 @@ const prepareDomainMessage = ({
   const escapedDomain = escapeMarkdown(domain);
   const whoisUrl = `https://nic\\.kz/cgi\\-bin/whois?query=${escapedDomain}`;
 
-  if (orgName) {
+  if (orgName && orgName !== '[HIDDEN PERSONAL DATA]') {
     return [
       `*Домен:* ${escapedDomain} \\- [Whois](${whoisUrl})\n`,
       `*Организация:* ${escapeMarkdown(orgName)}`,
+      `*Регистратор:* ${escapeMarkdown(registrar || '')}`,
       `*Клиент:* ${escapeMarkdown(cleanFromPersonalData(clientName || ''))}`,
       `*Email:* ${escapeMarkdown(clientEmail || '')}`,
       `*Адрес*: ${escapeMarkdown(clientAddress || '')}`,

--- a/whois.js
+++ b/whois.js
@@ -10,6 +10,11 @@ const findFieldByAttr = (data, field) => data.find((item) => item.attribute.star
 
 const findFieldsByAttrs = (data, fields) => fields.map((field) => findFieldByAttr(data, field));
 
+const findRegistrar = (data) =>
+  data.find((item) => item.attribute.toLowerCase().includes('registrar')) || {
+    value: '',
+  };
+
 const whoisAndParse = (
   domainToParse,
   returnFull = false,
@@ -37,22 +42,20 @@ const whoisAndParse = (
         return resolve(data);
       }
 
-      const [
-        orgName,
-        clientName,
-        clientPhoneNumber,
-        clientEmail,
-        clientAddress,
-      ] = findFieldsByAttrs(whoisData, [
-        'Organization Name',
-        'Name',
-        'Phone Number',
-        'Email Address',
-        'Street Address',
-      ]);
+      const [orgName, clientName, clientPhoneNumber, clientEmail, clientAddress] =
+        findFieldsByAttrs(whoisData, [
+          'Organization Name',
+          'Name',
+          'Phone Number',
+          'Email Address',
+          'Street Address',
+        ]);
+
+      const registrar = findRegistrar(whoisData);
 
       const parsedData = {
         orgName: orgName.value || 'Не указано',
+        registrar: registrar.value || 'Не указан',
         clientName: clientName.value || 'Не указано',
         clientPhoneNumber: clientPhoneNumber.value || 'Не указан',
         clientEmail: clientEmail.value || 'Не указан',


### PR DESCRIPTION
## Summary
- handle org info hidden cases when formatting domain info
- parse registrar from Whois data

## Testing
- `node -e "require('./helpers.js');"`
- `node -e "require('./whois.js');"`


------
https://chatgpt.com/codex/tasks/task_e_6869073a5878832fb077f97cd9fb0222